### PR TITLE
Now you won't have an error if in your template you using more 1 <tem…

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,8 @@ module.exports = function(options) {
                     treeAdapter.appendChild(docFragment, node);
 
                     template = parse5.serialize(docFragment);
-                    template = template.replace('<template>', '').replace('</template>', '');
+                    template = template.replace('<template>', '');
+                    template = template.substring(0, template.lastIndexOf('</template>'))
                 }
 
                 tagContent['template'] = minify(template.replace(/'/g, '&#39;'));


### PR DESCRIPTION
…plate></template> word

You solution will be wrong in selected situation:

<template>
      <some-conponent-with-slots>
            <template #header>{{ololo}}</template>
            <template #body>{{trololo}}</template>
            <template #footer>{{trulala}}</template>
      </some-conponent-with-slots>
<template>